### PR TITLE
[Fix] Change permissions for content to write

### DIFF
--- a/.github/workflows/python-client-publish.yaml
+++ b/.github/workflows/python-client-publish.yaml
@@ -5,7 +5,7 @@ on:
     tags: [python-client-v*]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:

--- a/.github/workflows/python-sdk-publish.yaml
+++ b/.github/workflows/python-sdk-publish.yaml
@@ -5,7 +5,7 @@ on:
     tags: [python-sdk-v*]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:


### PR DESCRIPTION
As you can see [here](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents), you need `write` permission for creating `release` (POST `/repos/{owner}/{repo}/releases` endpoint)